### PR TITLE
Add initial implementation of XenForo to GitHub Discussions migration tool

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+indent_style = space
+
+[docker-compose.yml]
+indent_size = 4
+indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+
+*.md diff=markdown
+
+LICENSE export-ignore
+README.md export-ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Test
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+        
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+          
+    - name: Download dependencies
+      run: go mod download
+      
+    - name: Run tests
+      run: go test -v -race -coverprofile=coverage.out ./...
+      
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.out
+        
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+        
+    - name: Build binary
+      run: go build -v -o xenforo-to-gh-discussions .
+      
+    - name: Test binary execution
+      run: ./xenforo-to-gh-discussions --help || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,goland+all,go,windows
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,goland+all,go,windows
+
+### Go ###
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #
@@ -11,22 +15,160 @@
 # Test binary, built with `go test -c`
 *.test
 
-# Code coverage profiles and other test artifacts
+# Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-coverage.*
-*.coverprofile
-profile.cov
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
 # Go workspace file
 go.work
-go.work.sum
 
-# env file
-.env
+### GoLand+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# Editor/IDE
-# .idea/
-# .vscode/
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### GoLand+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,goland+all,go,windows

--- a/README.md
+++ b/README.md
@@ -1,2 +1,273 @@
-# xenforo-to-gh-discussions
-A Golang script that seamlessly converts XenForo 2 forum threads into GitHub Discussions! 🌟 Perfect for migrating your community discussions to a modern, developer-friendly platform.
+# XenForo to GitHub Discussions Migration Tool
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/exileum/xenforo-to-gh-discussions)](https://goreportcard.com/report/github.com/exileum/xenforo-to-gh-discussions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Go Version](https://img.shields.io/badge/Go-1.24+-blue.svg)](https://golang.org)
+
+A robust Go CLI tool to migrate forum threads, posts, and attachments from XenForo 2 to GitHub Discussions using their respective APIs.
+
+## Features
+
+- **GraphQL-based GitHub Integration**: Uses GitHub's GraphQL API for creating discussions and comments
+- **Comprehensive BB-Code Support**: Converts XenForo BB codes to Markdown, including:
+    - Text formatting (bold, italic, underline, strikethrough)
+    - URLs and images
+    - Quotes (with attribution)
+    - Code blocks
+    - Spoilers (both block and inline)
+    - Lists
+    - Media embeds
+- **Smart Attachment Handling**:
+    - Downloads attachments and organizes by file type
+    - Embeds images directly in Markdown
+    - Links to other file types
+- **Robust Error Handling**:
+    - Retry logic with exponential backoff for rate limits
+    - Progress tracking for resumable migrations
+    - Detailed error logging
+- **Migration Features**:
+    - Dry-run mode for testing
+    - Pre-flight checks to validate configuration
+    - Progress tracking with JSON persistence
+    - Rate limiting compliance
+
+## Installation
+
+### Install from source
+
+```bash
+go install github.com/exileum/xenforo-to-gh-discussions@latest
+```
+
+### Clone and build
+
+```bash
+git clone https://github.com/exileum/xenforo-to-gh-discussions.git
+cd xenforo-to-gh-discussions
+go build -o xenforo-to-gh-discussions .
+```
+
+### Install dependencies manually
+
+```bash
+go mod download
+```
+
+## Prerequisites
+
+- Go 1.24 or higher
+- XenForo 2 with REST API enabled
+- GitHub repository with Discussions enabled
+- API credentials for both platforms
+
+## Configuration
+
+Edit the constants in `main.go`:
+
+```go
+var (
+    XenForoAPIURL  = "https://your-forum.com/api"
+    XenForoAPIKey  = "your_xenforo_api_key"
+    XenForoAPIUser = "1"  // Admin user ID
+    GitHubToken    = "your_github_token"
+    GitHubRepo     = "owner/repository"
+    TargetNodeID   = 1    // XenForo forum ID to migrate
+)
+```
+
+### Setting up XenForo API
+
+1. Enable REST API in XenForo Admin Panel
+2. Create a superuser API key with read access to:
+    - `/threads`
+    - `/posts`
+    - `/attachments`
+3. Note the user ID of the admin account
+
+### Setting up GitHub
+
+1. Create a personal access token with scopes:
+    - `repo`
+    - `write:discussion`
+2. Enable GitHub Discussions in your target repository
+3. Create discussion categories as needed
+
+### Getting GitHub Category IDs
+
+To find category IDs for the `NodeToCategory` mapping:
+
+```bash
+# Using GitHub CLI
+gh api graphql -f query='
+  query {
+    repository(owner: "OWNER", name: "REPO") {
+      discussionCategories(first: 100) {
+        nodes {
+          id
+          name
+        }
+      }
+    }
+  }'
+```
+
+Update the `NodeToCategory` map with your mappings:
+
+```go
+var NodeToCategory = map[int]string{
+    1: "DIC_kwDOxxxxxxxx",  // Your actual category ID
+    2: "DIC_kwDOyyyyyyyy",
+}
+```
+
+## Usage
+
+### Basic Migration
+
+```bash
+./xenforo-to-gh-discussions
+```
+
+### Dry Run Mode
+
+Test the migration without making actual changes:
+
+```bash
+./xenforo-to-gh-discussions --dry-run
+```
+
+### Verbose Mode
+
+See detailed output including converted content:
+
+```bash
+./xenforo-to-gh-discussions --dry-run --verbose
+```
+
+### Resume from Specific Thread
+
+Resume migration from a specific thread ID:
+
+```bash
+./xenforo-to-gh-discussions --resume-from=123
+```
+
+### Command Line Options
+
+- `--dry-run`: Run without making actual API calls
+- `--verbose`: Enable detailed logging
+- `--resume-from=ID`: Resume from specific thread ID
+
+## Output Structure
+
+### Attachments
+
+Downloaded attachments are organized by file type:
+
+```
+./attachments/
+├── png/
+│   ├── attachment_123_screenshot.png
+│   └── attachment_456_diagram.png
+├── jpg/
+│   └── attachment_789_photo.jpg
+├── zip/
+│   └── attachment_012_archive.zip
+└── pdf/
+    └── attachment_345_document.pdf
+```
+
+### Discussion Format
+
+Each discussion includes metadata in the following format:
+
+```markdown
+---
+Author: username
+Posted: 2025-01-15 14:30:00 UTC
+Original Thread ID: 12345
+---
+
+[Message content with converted Markdown]
+```
+
+## Progress Tracking
+
+The tool automatically saves progress to `migration_progress.json`:
+
+```json
+{
+  "last_thread_id": 456,
+  "completed_threads": [123, 456],
+  "failed_threads": [],
+  "last_updated": 1642353000
+}
+```
+
+Migration automatically resumes from the last successful thread if interrupted.
+
+## Development
+
+### Running Tests
+
+```bash
+go test -v ./...
+```
+
+### Running with Coverage
+
+```bash
+go test -cover ./...
+```
+
+### Build for Multiple Platforms
+
+```bash
+# Linux
+GOOS=linux GOARCH=amd64 go build -o xenforo-to-gh-discussions-linux .
+
+# Windows
+GOOS=windows GOARCH=amd64 go build -o xenforo-to-gh-discussions.exe .
+
+# macOS
+GOOS=darwin GOARCH=amd64 go build -o xenforo-to-gh-discussions-macos .
+```
+
+## Troubleshooting
+
+### Pre-flight Check Failures
+
+- **XenForo API authentication failed**: Verify API key and user ID
+- **GitHub Discussions not enabled**: Enable Discussions in repository settings
+- **Invalid category ID**: Use the GraphQL query above to get valid category IDs
+
+### Common Issues
+
+1. **Rate Limiting**: The tool automatically handles rate limits with exponential backoff
+2. **Large Attachments**: Consider increasing timeout values for large file downloads
+3. **Memory Usage**: For forums with many threads, consider migrating in batches by updating `TargetNodeID`
+
+## Security Notes
+
+- Never commit the script with actual API credentials
+- Use environment variables for production deployments
+- Ensure the attachment repository is public if you want images to display
+
+## Contributing
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the branch (`git push origin feature/AmazingFeature`)
+5. Open a Pull Request
+
+## License
+
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
+
+## Acknowledgments
+
+- [XenForo REST API Documentation](https://xenforo.com/docs/dev/rest-api/)
+- [GitHub Discussions API](https://docs.github.com/en/rest/discussions)
+- [Go Resty Library](https://github.com/go-resty/resty)
+- [GitHub GraphQL Client](https://github.com/shurcooL/githubv4)

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,362 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// TestRetryableRequest tests the retry logic with exponential backoff
+func TestRetryableRequest(t *testing.T) {
+	tests := []struct {
+		name          string
+		responses     []int         // Status codes to return
+		expectedCalls int           // Expected number of API calls
+		expectError   bool          // Whether we expect an error
+		minDuration   time.Duration // Minimum expected duration (for backoff)
+	}{
+		{
+			name:          "Successful on first try",
+			responses:     []int{200},
+			expectedCalls: 1,
+			expectError:   false,
+			minDuration:   0,
+		},
+		{
+			name:          "Rate limited then success",
+			responses:     []int{429, 200},
+			expectedCalls: 2,
+			expectError:   false,
+			minDuration:   1 * time.Second, // First retry after 1 second
+		},
+		{
+			name:          "Multiple rate limits then success",
+			responses:     []int{429, 429, 200},
+			expectedCalls: 3,
+			expectError:   false,
+			minDuration:   3 * time.Second, // 1s + 2s backoff
+		},
+		{
+			name:          "Max retries exceeded",
+			responses:     []int{429, 429, 429, 429}, // More than MaxRetries
+			expectedCalls: MaxRetries,
+			expectError:   true,
+			minDuration:   3 * time.Second, // 1s + 2s backoff (no 3rd retry)
+		},
+		{
+			name:          "Non-429 error",
+			responses:     []int{500},
+			expectedCalls: 1,
+			expectError:   false, // Returns response even with error status
+			minDuration:   0,
+		},
+		{
+			name:          "404 Not Found",
+			responses:     []int{404},
+			expectedCalls: 1,
+			expectError:   false,
+			minDuration:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callCount := 0
+			responseIndex := 0
+
+			// Create test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				if responseIndex < len(tt.responses) {
+					w.WriteHeader(tt.responses[responseIndex])
+					responseIndex++
+				} else {
+					w.WriteHeader(200)
+				}
+				w.Write([]byte(`{"status": "ok"}`))
+			}))
+			defer server.Close()
+
+			// Create test client
+			testClient := resty.New()
+
+			start := time.Now()
+
+			// Make request with retry logic
+			resp, err := retryableRequest(func() (*resty.Response, error) {
+				return testClient.R().Get(server.URL)
+			})
+
+			duration := time.Since(start)
+
+			// Check error expectation
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			} else if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Check number of calls
+			if callCount != tt.expectedCalls {
+				t.Errorf("Expected %d calls, got %d", tt.expectedCalls, callCount)
+			}
+
+			// Check response
+			if !tt.expectError && resp != nil {
+				lastStatusIndex := len(tt.responses) - 1
+				if lastStatusIndex >= 0 && responseIndex > 0 {
+					expectedStatus := tt.responses[responseIndex-1]
+					if resp.StatusCode() != expectedStatus {
+						t.Errorf("Expected status %d, got %d", expectedStatus, resp.StatusCode())
+					}
+				}
+			}
+
+			// Check minimum duration for backoff
+			if duration < tt.minDuration {
+				t.Errorf("Expected minimum duration %v, but completed in %v", tt.minDuration, duration)
+			}
+		})
+	}
+}
+
+// TestPreflightChecks tests the pre-flight validation
+func TestPreflightChecks(t *testing.T) {
+	// Save original values
+	originalDryRun := dryRun
+	originalClient := client
+	originalAPIKey := XenForoAPIKey
+	defer func() {
+		dryRun = originalDryRun
+		client = originalClient
+		XenForoAPIKey = originalAPIKey
+	}()
+
+	tests := []struct {
+		name        string
+		setupFunc   func(*httptest.Server)
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "Dry run mode - should pass",
+			setupFunc: func(server *httptest.Server) {
+				dryRun = true
+			},
+			expectError: false,
+		},
+		{
+			name: "XenForo API authentication failed",
+			setupFunc: func(server *httptest.Server) {
+				dryRun = false
+				// Create client without API key to trigger 401
+				client = resty.New()
+				// Don't set XF-Api-Key header to trigger authentication failure
+				XenForoAPIKey = ""
+				// Set githubClient to nil to avoid nil pointer dereference
+				githubClient = nil
+			},
+			expectError: true,
+			errorMsg:    "authentication failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Check XenForo API headers
+				if r.Header.Get("XF-Api-Key") == "" {
+					w.WriteHeader(401)
+					return
+				}
+				w.WriteHeader(200)
+				w.Write([]byte(`{"api": {"version": "1.0"}}`))
+			}))
+			defer server.Close()
+
+			// Override API URL for testing
+			oldURL := XenForoAPIURL
+			defer func() {
+				XenForoAPIURL = oldURL
+			}()
+			XenForoAPIURL = server.URL
+
+			tt.setupFunc(server)
+
+			err := runPreflightChecks()
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error containing '%s' but got none", tt.errorMsg)
+			} else if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			} else if tt.expectError && err != nil && !contains(err.Error(), tt.errorMsg) {
+				t.Errorf("Expected error containing '%s', got '%s'", tt.errorMsg, err.Error())
+			}
+		})
+	}
+}
+
+// MockXenForoAPI creates a mock XenForo API server for testing
+func MockXenForoAPI(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check authentication
+		if r.Header.Get("XF-Api-Key") != "test-key" {
+			w.WriteHeader(401)
+			w.Write([]byte(`{"errors": [{"code": "unauthorized"}]}`))
+			return
+		}
+
+		switch r.URL.Path {
+		case "/threads":
+			page := r.URL.Query().Get("page")
+			if page == "" || page == "1" {
+				response := map[string]interface{}{
+					"threads": []XenForoThread{
+						{ThreadID: 1, Title: "Test Thread 1", NodeID: 1, Username: "user1", PostDate: time.Now().Unix()},
+						{ThreadID: 2, Title: "Test Thread 2", NodeID: 1, Username: "user2", PostDate: time.Now().Unix()},
+					},
+					"pagination": map[string]int{
+						"current_page": 1,
+						"total_pages":  1,
+					},
+				}
+				json.NewEncoder(w).Encode(response)
+			}
+
+		case "/threads/1/posts":
+			response := map[string]interface{}{
+				"posts": []XenForoPost{
+					{PostID: 1, ThreadID: 1, Username: "user1", PostDate: time.Now().Unix(), Message: "[b]First post[/b]"},
+					{PostID: 2, ThreadID: 1, Username: "user2", PostDate: time.Now().Unix(), Message: "Reply with [i]italic[/i]"},
+				},
+				"pagination": map[string]int{
+					"current_page": 1,
+					"total_pages":  1,
+				},
+			}
+			json.NewEncoder(w).Encode(response)
+
+		case "/threads/1/attachments":
+			response := map[string]interface{}{
+				"attachments": []XenForoAttachment{
+					{AttachmentID: 1, Filename: "test.png", ViewURL: fmt.Sprintf("%s/attachments/1", r.Host)},
+				},
+			}
+			json.NewEncoder(w).Encode(response)
+
+		case "/attachments/1":
+			// Serve a mock image
+			w.Header().Set("Content-Type", "image/png")
+			w.Write([]byte("PNG_DATA"))
+
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+}
+
+// Helper function to check if string contains substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && s[0:len(substr)] == substr || len(s) > len(substr) && s[len(s)-len(substr):] == substr || (len(substr) > 0 && len(s) > len(substr) && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAPIErrorHandling tests various API error scenarios
+func TestAPIErrorHandling(t *testing.T) {
+	// Save original values
+	originalClient := client
+	originalAPIURL := XenForoAPIURL
+	defer func() {
+		client = originalClient
+		XenForoAPIURL = originalAPIURL
+	}()
+
+	tests := []struct {
+		name          string
+		endpoint      string
+		statusCode    int
+		responseBody  string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "XenForo 404",
+			endpoint:      "/threads",
+			statusCode:    404,
+			responseBody:  `{"errors": [{"code": "not_found"}]}`,
+			expectError:   true,
+			errorContains: "XenForo API error",
+		},
+		{
+			name:          "XenForo 500",
+			endpoint:      "/threads",
+			statusCode:    500,
+			responseBody:  `{"errors": [{"code": "server_error"}]}`,
+			expectError:   true,
+			errorContains: "XenForo API error",
+		},
+		{
+			name:          "Invalid JSON response",
+			endpoint:      "/threads",
+			statusCode:    200,
+			responseBody:  `{invalid json`,
+			expectError:   true,
+			errorContains: "",
+		},
+		{
+			name:         "Empty response",
+			endpoint:     "/threads",
+			statusCode:   200,
+			responseBody: `{"threads": [], "pagination": {"current_page": 1, "total_pages": 1}}`,
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			// Override API URL to point to mock server
+			XenForoAPIURL = server.URL
+			client = resty.New()
+
+			// Test based on endpoint
+			var err error
+			switch tt.endpoint {
+			case "/threads":
+				_, err = getXenForoThreads(1)
+			case "/posts":
+				_, err = getXenForoPosts(1)
+			case "/attachments":
+				_, err = getXenForoAttachments(1)
+			}
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			} else if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			} else if tt.expectError && tt.errorContains != "" && !contains(err.Error(), tt.errorContains) {
+				t.Errorf("Expected error containing '%s', got '%s'", tt.errorContains, err.Error())
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/exileum/xenforo-to-gh-discussions
+
+go 1.24
+
+require (
+	github.com/go-resty/resty/v2 v2.16.5 // indirect
+	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 // indirect
+	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
+	golang.org/x/net v0.33.0 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
+github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
+github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 h1:cYCy18SHPKRkvclm+pWm1Lk4YrREb4IOIb/YdFO0p2M=
+github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7/go.mod h1:zqMwyHmnN/eDOZOdiTohqIUKUrTFX62PNlu7IJdu0q8=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// MockGitHubClient implements a mock GitHub GraphQL client for testing
+type MockGitHubClient struct {
+	CreateDiscussionFunc func(input githubv4.CreateDiscussionInput) (string, int, error)
+	AddCommentFunc       func(input githubv4.AddDiscussionCommentInput) error
+	QueryFunc            func(ctx context.Context, q interface{}, variables map[string]interface{}) error
+}
+
+func (m *MockGitHubClient) Mutate(ctx context.Context, mutation interface{}, input interface{}, variables map[string]interface{}) error {
+	// Handle different mutation types based on the input type
+	switch v := input.(type) {
+	case githubv4.CreateDiscussionInput:
+		if m.CreateDiscussionFunc != nil {
+			_, _, err := m.CreateDiscussionFunc(v)
+			if err != nil {
+				return err
+			}
+			// Use reflection to set the response (simplified for testing)
+			// In real implementation, would properly set the mutation response
+			return nil
+		}
+	case githubv4.AddDiscussionCommentInput:
+		if m.AddCommentFunc != nil {
+			return m.AddCommentFunc(v)
+		}
+	}
+	return nil
+}
+
+func (m *MockGitHubClient) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+	if m.QueryFunc != nil {
+		return m.QueryFunc(ctx, q, variables)
+	}
+	return nil
+}
+
+// TestEndToEndMigration tests the complete migration flow with mocked APIs
+func TestEndToEndMigration(t *testing.T) {
+	// Create temporary directory for test
+	tempDir, err := os.MkdirTemp("", "godisc-e2e-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Save original values
+	originalDryRun := dryRun
+	originalClient := client
+	defer func() {
+		dryRun = originalDryRun
+		client = originalClient
+		progress = nil
+	}()
+
+	// Configure for test
+	dryRun = false
+	oldAttachmentsDir := AttachmentsDir
+	oldProgressFile := ProgressFile
+	defer func() {
+		AttachmentsDir = oldAttachmentsDir
+		ProgressFile = oldProgressFile
+	}()
+	AttachmentsDir = filepath.Join(tempDir, "attachments")
+	ProgressFile = filepath.Join(tempDir, "progress.json")
+
+	// Initialize progress
+	progress = &MigrationProgress{
+		CompletedThreads: []int{},
+		FailedThreads:    []int{},
+	}
+
+	// Test data
+	testThreads := []XenForoThread{
+		{
+			ThreadID:    1,
+			Title:       "Test Migration Thread",
+			NodeID:      1,
+			Username:    "testuser",
+			PostDate:    1642353000,
+			FirstPostID: 1,
+		},
+	}
+
+	testPosts := []XenForoPost{
+		{
+			PostID:   1,
+			ThreadID: 1,
+			Username: "testuser",
+			PostDate: 1642353000,
+			Message:  "This is a [b]test post[/b] with [ATTACH=1].",
+		},
+		{
+			PostID:   2,
+			ThreadID: 1,
+			Username: "replyuser",
+			PostDate: 1642353600,
+			Message:  "[quote=\"testuser\"]test post[/quote]\nI agree!",
+		},
+	}
+
+	testAttachments := []XenForoAttachment{
+		{
+			AttachmentID: 1,
+			Filename:     "test-image.png",
+			ViewURL:      "https://example.com/attach/1",
+		},
+	}
+
+	// Create test scenarios
+	tests := []struct {
+		name          string
+		setupFunc     func()
+		expectSuccess bool
+		checkFunc     func(t *testing.T)
+	}{
+		{
+			name: "Successful migration",
+			setupFunc: func() {
+				// Reset progress
+				progress.CompletedThreads = []int{}
+				progress.FailedThreads = []int{}
+			},
+			expectSuccess: true,
+			checkFunc: func(t *testing.T) {
+				// Check progress was saved
+				if len(progress.CompletedThreads) != 1 {
+					t.Errorf("Expected 1 completed thread, got %d", len(progress.CompletedThreads))
+				}
+				if len(progress.FailedThreads) != 0 {
+					t.Errorf("Expected 0 failed threads, got %d", len(progress.FailedThreads))
+				}
+
+				// Check attachments directory was created
+				if _, err := os.Stat(filepath.Join(AttachmentsDir, "png")); os.IsNotExist(err) {
+					t.Error("Attachments directory not created")
+				}
+			},
+		},
+		{
+			name: "Skip already completed threads",
+			setupFunc: func() {
+				progress.CompletedThreads = []int{1}
+				progress.FailedThreads = []int{}
+			},
+			expectSuccess: true,
+			checkFunc: func(t *testing.T) {
+				// Should still have only 1 completed thread
+				if len(progress.CompletedThreads) != 1 {
+					t.Errorf("Expected 1 completed thread, got %d", len(progress.CompletedThreads))
+				}
+			},
+		},
+		{
+			name: "Handle missing category mapping",
+			setupFunc: func() {
+				// Temporarily change thread to unmapped node
+				testThreads[0].NodeID = 999
+				progress.CompletedThreads = []int{}
+			},
+			expectSuccess: true,
+			checkFunc: func(t *testing.T) {
+				// Should not be in completed or failed
+				if len(progress.CompletedThreads) != 0 {
+					t.Errorf("Expected 0 completed threads, got %d", len(progress.CompletedThreads))
+				}
+				if len(progress.FailedThreads) != 0 {
+					t.Errorf("Expected 0 failed threads, got %d", len(progress.FailedThreads))
+				}
+				// Reset for next test
+				testThreads[0].NodeID = 1
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupFunc()
+
+			// Simulate the migration process components
+			// 1. Filter completed threads
+			filteredThreads := filterCompletedThreads(testThreads)
+
+			// 2. Process each thread
+			for _, thread := range filteredThreads {
+				// Check category mapping
+				_, hasCategory := NodeToCategory[thread.NodeID]
+				if !hasCategory {
+					continue
+				}
+
+				// 3. Create attachment directories (simulate download)
+				for _, attachment := range testAttachments {
+					ext := strings.ToLower(filepath.Ext(attachment.Filename))
+					if ext == "" {
+						ext = ".unknown"
+					}
+					ext = strings.TrimPrefix(ext, ".")
+					
+					dirPath := filepath.Join(AttachmentsDir, ext)
+					if err := os.MkdirAll(dirPath, 0755); err != nil {
+						t.Errorf("Failed to create attachment directory: %v", err)
+					}
+				}
+
+				// 4. Convert posts
+				for i, post := range testPosts {
+					markdown := convertBBCodeToMarkdown(post.Message)
+					markdown = replaceAttachmentLinks(markdown, testAttachments)
+					body := formatMessage(post.Username, post.PostDate, thread.ThreadID, markdown)
+
+					// Verify conversion
+					if i == 0 {
+						if body == "" {
+							t.Error("First post body is empty")
+						}
+						if !contains(body, "**test post**") {
+							t.Error("BB-code not converted properly")
+						}
+						if !contains(body, "![test-image.png](./png/attachment_1_test-image.png)") {
+							t.Error("Attachment not replaced properly")
+						}
+					}
+				}
+
+				// 5. Mark as completed (in real flow)
+				if hasCategory {
+					progress.CompletedThreads = append(progress.CompletedThreads, thread.ThreadID)
+				}
+			}
+
+			// 6. Save progress
+			saveProgress()
+
+			// Run checks
+			tt.checkFunc(t)
+		})
+	}
+}
+
+// TestDryRunMode tests that dry-run mode doesn't make actual changes
+func TestDryRunMode(t *testing.T) {
+	// Save original values
+	originalDryRun := dryRun
+	originalVerbose := verbose
+	defer func() {
+		dryRun = originalDryRun
+		verbose = originalVerbose
+	}()
+
+	// Enable dry-run and verbose mode
+	dryRun = true
+	verbose = true
+
+	// Create a temporary directory
+	tempDir, err := os.MkdirTemp("", "godisc-dryrun-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	oldAttachmentsDir := AttachmentsDir
+	defer func() {
+		AttachmentsDir = oldAttachmentsDir
+	}()
+	AttachmentsDir = filepath.Join(tempDir, "attachments")
+
+	// Test attachment download in dry-run mode
+	attachments := []XenForoAttachment{
+		{AttachmentID: 1, Filename: "test.png", ViewURL: "https://example.com/1"},
+	}
+
+	// This should not create any files
+	downloadAttachments(attachments)
+
+	// Verify no files were created
+	if _, err := os.Stat(AttachmentsDir); !os.IsNotExist(err) {
+		t.Error("Attachments directory should not be created in dry-run mode")
+	}
+}
+
+// TestConcurrentOperations tests thread safety of shared resources
+func TestConcurrentOperations(t *testing.T) {
+	// This test ensures that concurrent operations don't cause race conditions
+	// In a real implementation, you would test actual concurrent API calls
+
+	// Save original progress
+	originalProgress := progress
+	defer func() {
+		progress = originalProgress
+	}()
+
+	// Initialize test progress
+	progress = &MigrationProgress{
+		CompletedThreads: []int{},
+		FailedThreads:    []int{},
+	}
+
+	// Simulate concurrent updates to progress
+	done := make(chan bool, 2)
+
+	go func() {
+		progress.CompletedThreads = append(progress.CompletedThreads, 1)
+		done <- true
+	}()
+
+	go func() {
+		progress.FailedThreads = append(progress.FailedThreads, 2)
+		done <- true
+	}()
+
+	// Wait for both operations
+	<-done
+	<-done
+
+	// In a real implementation, you would use proper synchronization
+	// This test is simplified to demonstrate the concept
+	if len(progress.CompletedThreads) == 0 && len(progress.FailedThreads) == 0 {
+		t.Error("Concurrent operations may have caused data loss")
+	}
+}
+
+// TestLargeDatasetHandling tests performance with large datasets
+func TestLargeDatasetHandling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping large dataset test in short mode")
+	}
+
+	// Generate large dataset
+	largeText := generateLargeText(10000) // 10KB of text
+
+	// Test BB-code conversion performance
+	start := time.Now()
+	result := convertBBCodeToMarkdown(largeText)
+	duration := time.Since(start)
+
+	if duration > 1*time.Second {
+		t.Errorf("BB-code conversion took too long: %v", duration)
+	}
+
+	if len(result) == 0 {
+		t.Error("Large text conversion resulted in empty output")
+	}
+}
+
+// Helper function to generate large text with BB-codes
+func generateLargeText(size int) string {
+	var text string
+	bbcodes := []string{"[b]bold[/b]", "[i]italic[/i]", "[url=http://example.com]link[/url]"}
+
+	for len(text) < size {
+		text += fmt.Sprintf("This is line with %s text. ", bbcodes[len(text)%len(bbcodes)])
+	}
+
+	return text
+}
+
+// TestMemoryLeaks checks for potential memory leaks
+func TestMemoryLeaks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping memory leak test in short mode")
+	}
+
+	// Run multiple iterations of BB-code conversion
+	for i := 0; i < 1000; i++ {
+		input := fmt.Sprintf("[b]Test %d[/b] with [i]formatting[/i] and [url=http://example.com]links[/url]", i)
+		_ = convertBBCodeToMarkdown(input)
+	}
+
+	// In a real test, you would measure memory usage
+	// This is a simplified version to demonstrate the concept
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,791 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+)
+
+// Configuration
+var (
+	XenForoAPIURL  = "https://your-forum.com/api" // XenForo API URL
+	XenForoAPIKey  = "your_xenforo_api_key"       // XenForo super user API key
+	XenForoAPIUser = "1"                          // Super user ID (e.g., 1 for admin)
+	GitHubToken    = "your_github_token"          // GitHub personal access token
+	GitHubRepo     = "your_username/your_repo"    // Repository for Discussions (owner/repo)
+	AttachmentsDir = "./attachments"              // Local directory for downloaded attachments
+	TargetNodeID   = 1                            // XenForo forum ID to migrate
+	MaxRetries     = 3                            // Maximum retry attempts for failed requests
+	ProgressFile   = "migration_progress.json"    // File to track migration progress
+)
+
+// NodeToCategory maps XenForo node_id to GitHub discussion category_id
+var NodeToCategory = map[int]string{
+	1: "DIC_kwDOxxxxxxxx", // Replace with actual category ID from GitHub
+	// Add more mappings as needed
+}
+
+// XenForoThread XenForo API structures
+type XenForoThread struct {
+	ThreadID    int    `json:"thread_id"`
+	Title       string `json:"title"`
+	NodeID      int    `json:"node_id"`
+	Username    string `json:"username"`
+	PostDate    int64  `json:"post_date"`
+	FirstPostID int    `json:"first_post_id"`
+}
+
+type XenForoPost struct {
+	PostID   int    `json:"post_id"`
+	ThreadID int    `json:"thread_id"`
+	Username string `json:"username"`
+	PostDate int64  `json:"post_date"`
+	Message  string `json:"message"`
+}
+
+type XenForoAttachment struct {
+	AttachmentID int    `json:"attachment_id"`
+	Filename     string `json:"filename"`
+	ViewURL      string `json:"view_url"`
+}
+
+// Progress tracking
+type MigrationProgress struct {
+	LastThreadID     int   `json:"last_thread_id"`
+	CompletedThreads []int `json:"completed_threads"`
+	FailedThreads    []int `json:"failed_threads"`
+	LastUpdated      int64 `json:"last_updated"`
+}
+
+// GitHub GraphQL mutations
+const createDiscussionMutation = `
+mutation($input: CreateDiscussionInput!) {
+	createDiscussion(input: $input) {
+		discussion {
+			id
+			number
+		}
+	}
+}
+`
+
+const addDiscussionCommentMutation = `
+mutation($input: AddDiscussionCommentInput!) {
+	addDiscussionComment(input: $input) {
+		comment {
+			id
+		}
+	}
+}
+`
+
+var (
+	dryRun       bool
+	resumeFrom   int
+	verbose      bool
+	client       = resty.New()
+	githubClient *githubv4.Client
+	repositoryID string
+	progress     *MigrationProgress
+)
+
+func init() {
+	flag.BoolVar(&dryRun, "dry-run", false, "Run in dry-run mode (no actual API calls)")
+	flag.IntVar(&resumeFrom, "resume-from", 0, "Resume from specific thread ID")
+	flag.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
+}
+
+func main() {
+	flag.Parse()
+
+	// Load or initialize progress
+	progress = loadProgress()
+	if resumeFrom > 0 {
+		progress.LastThreadID = resumeFrom
+	}
+
+	// Initialize GitHub GraphQL client
+	if !dryRun {
+		src := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: GitHubToken},
+		)
+		httpClient := oauth2.NewClient(context.Background(), src)
+		githubClient = githubv4.NewClient(httpClient)
+	}
+
+	// Run pre-flight checks
+	log.Println("Running pre-flight checks...")
+	if err := runPreflightChecks(); err != nil {
+		log.Fatalf("Pre-flight checks failed: %v", err)
+	}
+	log.Println("✓ All pre-flight checks passed")
+
+	// Get threads from XenForo
+	log.Printf("Fetching threads from forum node %d...", TargetNodeID)
+	threads, err := getXenForoThreads(TargetNodeID)
+	if err != nil {
+		log.Fatalf("Failed to fetch threads: %v", err)
+	}
+	log.Printf("✓ Found %d threads to migrate", len(threads))
+
+	// Filter out already completed threads
+	threads = filterCompletedThreads(threads)
+	log.Printf("✓ %d threads remaining after filtering completed ones", len(threads))
+
+	// Process each thread
+	for i, thread := range threads {
+		log.Printf("\nProcessing thread %d/%d: %s", i+1, len(threads), thread.Title)
+
+		// Check if category mapping exists
+		categoryID, ok := NodeToCategory[thread.NodeID]
+		if !ok {
+			log.Printf("✗ Skipped: no category mapping for node_id %d", thread.NodeID)
+			continue
+		}
+
+		// Get posts for thread
+		posts, err := getXenForoPosts(thread.ThreadID)
+		if err != nil {
+			log.Printf("✗ Failed to fetch posts: %v", err)
+			progress.FailedThreads = append(progress.FailedThreads, thread.ThreadID)
+			saveProgress()
+			continue
+		}
+
+		// Get attachments for thread
+		attachments, err := getXenForoAttachments(thread.ThreadID)
+		if err != nil {
+			log.Printf("⚠ Warning: Failed to fetch attachments: %v", err)
+			// Continue anyway, just without attachments
+		}
+
+		// Download attachments
+		if len(attachments) > 0 && !dryRun {
+			log.Printf("  Downloading %d attachments...", len(attachments))
+			downloadAttachments(attachments)
+		}
+
+		// Create discussion
+		discussionID := ""
+		discussionNumber := 0
+
+		for j, post := range posts {
+			// Convert BB-codes to Markdown
+			markdown := convertBBCodeToMarkdown(post.Message)
+
+			// Replace attachment links
+			markdown = replaceAttachmentLinks(markdown, attachments)
+
+			// Format message with metadata
+			body := formatMessage(post.Username, post.PostDate, thread.ThreadID, markdown)
+
+			if j == 0 {
+				// Create discussion from first post
+				if dryRun {
+					log.Printf("  [DRY-RUN] Would create discussion: %s", thread.Title)
+					if verbose {
+						fmt.Printf("\n--- Discussion Body Preview ---\n%s\n--- End Preview ---\n", body)
+					}
+				} else {
+					id, num, err := createGitHubDiscussion(thread.Title, body, categoryID)
+					if err != nil {
+						log.Printf("✗ Failed to create discussion: %v", err)
+						progress.FailedThreads = append(progress.FailedThreads, thread.ThreadID)
+						saveProgress()
+						continue
+					}
+					discussionID = id
+					discussionNumber = num
+					log.Printf("✓ Created discussion #%d", discussionNumber)
+				}
+			} else {
+				// Add comment to discussion
+				if dryRun {
+					log.Printf("  [DRY-RUN] Would add comment by %s", post.Username)
+					if verbose {
+						fmt.Printf("\n--- Comment Preview ---\n%s\n--- End Preview ---\n", body)
+					}
+				} else if discussionID != "" {
+					err := addGitHubComment(discussionID, body)
+					if err != nil {
+						log.Printf("✗ Failed to add comment: %v", err)
+					} else {
+						log.Printf("  ✓ Added comment by %s", post.Username)
+					}
+				}
+			}
+
+			// Rate limiting
+			if !dryRun {
+				time.Sleep(1 * time.Second)
+			}
+		}
+
+		// Mark thread as completed
+		progress.CompletedThreads = append(progress.CompletedThreads, thread.ThreadID)
+		progress.LastThreadID = thread.ThreadID
+		saveProgress()
+	}
+
+	// Print summary
+	printSummary()
+}
+
+func runPreflightChecks() error {
+	// Check if dry-run mode
+	if dryRun {
+		log.Println("  Running in DRY-RUN mode - no actual changes will be made")
+		return nil
+	}
+
+	// Test XenForo API access
+	resp, err := client.R().
+		SetHeader("XF-Api-Key", XenForoAPIKey).
+		SetHeader("XF-Api-User", XenForoAPIUser).
+		Get(XenForoAPIURL + "/")
+	if err != nil {
+		return fmt.Errorf("XenForo API connection failed: %v", err)
+	}
+	if resp.StatusCode() == 401 {
+		return fmt.Errorf("XenForo API authentication failed - check API key and user ID")
+	}
+	log.Println("  ✓ XenForo API access verified")
+
+	// Get repository ID for GitHub
+	if !dryRun && githubClient != nil {
+		parts := strings.Split(GitHubRepo, "/")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid GitHub repository format - expected 'owner/repo'")
+		}
+
+		var query struct {
+			Repository struct {
+				ID                   string
+				DiscussionsEnabled   bool
+				DiscussionCategories struct {
+					Nodes []struct {
+						ID   string
+						Name string
+					}
+				} `graphql:"discussionCategories(first: 100)"`
+			} `graphql:"repository(owner: $owner, name: $name)"`
+		}
+
+		variables := map[string]interface{}{
+			"owner": githubv4.String(parts[0]),
+			"name":  githubv4.String(parts[1]),
+		}
+
+		err := githubClient.Query(context.Background(), &query, variables)
+		if err != nil {
+			return fmt.Errorf("GitHub API access failed: %v", err)
+		}
+
+		if !query.Repository.DiscussionsEnabled {
+			return fmt.Errorf("GitHub Discussions is not enabled for repository %s", GitHubRepo)
+		}
+
+		repositoryID = query.Repository.ID
+		log.Println("  ✓ GitHub API access verified")
+		log.Println("  ✓ GitHub Discussions is enabled")
+
+		// Verify category mappings
+		validCategories := make(map[string]bool)
+		for _, cat := range query.Repository.DiscussionCategories.Nodes {
+			validCategories[cat.ID] = true
+		}
+
+		for nodeID, categoryID := range NodeToCategory {
+			if !validCategories[categoryID] {
+				return fmt.Errorf("invalid category ID '%s' for node %d", categoryID, nodeID)
+			}
+		}
+		log.Println("  ✓ All category mappings are valid")
+	}
+
+	// Create attachments directory
+	if err := os.MkdirAll(AttachmentsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create attachments directory: %v", err)
+	}
+	log.Println("  ✓ Attachments directory ready")
+
+	return nil
+}
+
+func convertBBCodeToMarkdown(bbcode string) string {
+	// Handle empty or whitespace-only input
+	if strings.TrimSpace(bbcode) == "" {
+		return ""
+	}
+	
+	// First, handle multi-line code blocks
+	bbcode = regexp.MustCompile(`(?s)\[code\](.*?)\[/code\]`).ReplaceAllStringFunc(bbcode, func(match string) string {
+		parts := regexp.MustCompile(`(?s)\[code\](.*?)\[/code\]`).FindStringSubmatch(match)
+		if len(parts) < 2 {
+			return match
+		}
+		content := parts[1]
+		// Check if content starts with newline (multi-line)
+		if strings.HasPrefix(content, "\n") {
+			return "\n```\n" + strings.TrimSpace(content) + "\n```\n"
+		}
+		// Single line code
+		return "\n```\n" + strings.TrimSpace(content) + "\n```\n"
+	})
+
+	// Handle quotes with attribution (extract just the username, ignore extra params)
+	bbcode = regexp.MustCompile(`(?s)\[quote="([^,"]+)(?:,[^\]]+)?"\](.*?)\[/quote\]`).ReplaceAllStringFunc(bbcode, func(match string) string {
+		parts := regexp.MustCompile(`(?s)\[quote="([^,"]+)(?:,[^\]]+)?"\](.*?)\[/quote\]`).FindStringSubmatch(match)
+		if len(parts) < 3 {
+			return match
+		}
+		author := parts[1]
+		content := parts[2]
+		lines := strings.Split(strings.TrimSpace(content), "\n")
+		quoted := "> **" + author + " said:**\n"
+		for _, line := range lines {
+			quoted += "> " + line + "\n"
+		}
+		return quoted
+	})
+
+	// Handle simple quotes
+	bbcode = regexp.MustCompile(`(?s)\[quote\](.*?)\[/quote\]`).ReplaceAllStringFunc(bbcode, func(match string) string {
+		parts := regexp.MustCompile(`(?s)\[quote\](.*?)\[/quote\]`).FindStringSubmatch(match)
+		if len(parts) < 2 {
+			return match
+		}
+		content := parts[1]
+		lines := strings.Split(strings.TrimSpace(content), "\n")
+		quoted := ""
+		for _, line := range lines {
+			quoted += "> " + line + "\n"
+		}
+		return quoted
+	})
+
+	// URLs with quotes first
+	bbcode = regexp.MustCompile(`\[url="([^"]+)"\](.*?)\[/url\]`).ReplaceAllString(bbcode, "[$2]($1)")
+
+	// Simple replacements
+	replacements := []struct {
+		pattern     *regexp.Regexp
+		replacement string
+	}{
+		// Text formatting
+		{regexp.MustCompile(`\[b\](.*?)\[/b\]`), "**$1**"},
+		{regexp.MustCompile(`\[i\](.*?)\[/i\]`), "*$1*"},
+		{regexp.MustCompile(`\[u\](.*?)\[/u\]`), "<u>$1</u>"},
+		{regexp.MustCompile(`\[s\](.*?)\[/s\]`), "~~$1~~"},
+		{regexp.MustCompile(`\[strike\](.*?)\[/strike\]`), "~~$1~~"},
+
+		// URLs (without quotes)
+		{regexp.MustCompile(`\[url=([^\]]+)\](.*?)\[/url\]`), "[$2]($1)"},
+		{regexp.MustCompile(`\[url\](.*?)\[/url\]`), "[$1]($1)"},
+
+		// Images
+		{regexp.MustCompile(`\[img\](.*?)\[/img\]`), "![]($1)"},
+
+		// Spoilers
+		{regexp.MustCompile(`(?s)\[spoiler(?:="[^"]*")?\](.*?)\[/spoiler\]`), "<details><summary>Spoiler</summary>\n\n$1\n\n</details>"},
+		{regexp.MustCompile(`\[ispoiler\](.*?)\[/ispoiler\]`), "||$1||"},
+
+		// Media embeds
+		{regexp.MustCompile(`\[media=([^\]]+)\](.*?)\[/media\]`), "[$1]($2)"},
+
+		// Lists
+		{regexp.MustCompile(`\[\*\]`), "- "},
+		{regexp.MustCompile(`\[list=1\]\n`), "\n"},
+		{regexp.MustCompile(`\[list\]\n`), "\n"},
+		{regexp.MustCompile(`\n\[/list\]`), "\n"},
+
+		// Center alignment
+		{regexp.MustCompile(`\[center\](.*?)\[/center\]`), "<center>$1</center>"},
+
+		// Remove color, size, font tags
+		{regexp.MustCompile(`\[color=[^\]]+\](.*?)\[/color\]`), "$1"},
+		{regexp.MustCompile(`\[size=[^\]]+\](.*?)\[/size\]`), "$1"},
+		{regexp.MustCompile(`\[font=[^\]]+\](.*?)\[/font\]`), "$1"},
+	}
+
+	result := bbcode
+	for _, r := range replacements {
+		result = r.pattern.ReplaceAllString(result, r.replacement)
+	}
+
+	// Clean up any remaining unhandled BB codes (but not markdown links or ATTACH tags)
+	// Remove BB-code patterns but preserve markdown links [text](url) and ATTACH tags
+	result = regexp.MustCompile(`\[/?[a-zA-Z][a-zA-Z0-9=_-]*\]`).ReplaceAllStringFunc(result, func(match string) string {
+		// Check if this bracket is followed by a parenthesis (markdown link)
+		matchIndex := strings.Index(result, match)
+		if matchIndex >= 0 && matchIndex+len(match) < len(result) && result[matchIndex+len(match)] == '(' {
+			return match // Preserve markdown links
+		}
+		// Preserve ATTACH tags for later processing
+		if strings.HasPrefix(match, "[ATTACH") {
+			return match
+		}
+		return "" // Remove other BB-code tags
+	})
+
+	// Clean up excessive newlines (but preserve intentional trailing newlines)
+	result = regexp.MustCompile(`\n{3,}`).ReplaceAllString(result, "\n\n")
+
+	// Trim leading/trailing spaces but preserve newlines for proper formatting
+	result = strings.Trim(result, " \t")
+
+	return result
+}
+
+func formatMessage(username string, postDate int64, threadID int, content string) string {
+	timestamp := time.Unix(postDate, 0).UTC().Format("2006-01-02 15:04:05 UTC")
+	return fmt.Sprintf(`---
+Author: %s
+Posted: %s
+Original Thread ID: %d
+---
+
+%s`, username, timestamp, threadID, content)
+}
+
+func getXenForoThreads(nodeID int) ([]XenForoThread, error) {
+	var threads []XenForoThread
+	page := 1
+
+	for {
+		resp, err := retryableRequest(func() (*resty.Response, error) {
+			return client.R().
+				SetHeader("XF-Api-Key", XenForoAPIKey).
+				SetHeader("XF-Api-User", XenForoAPIUser).
+				SetQueryParams(map[string]string{
+					"page":    fmt.Sprintf("%d", page),
+					"node_id": fmt.Sprintf("%d", nodeID),
+				}).
+				Get(XenForoAPIURL + "/threads")
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode() != 200 {
+			return nil, fmt.Errorf("XenForo API error: %s", resp.String())
+		}
+
+		var result struct {
+			Threads    []XenForoThread `json:"threads"`
+			Pagination struct {
+				CurrentPage int `json:"current_page"`
+				TotalPages  int `json:"total_pages"`
+			} `json:"pagination"`
+		}
+
+		err = json.Unmarshal(resp.Body(), &result)
+		if err != nil {
+			return nil, err
+		}
+
+		threads = append(threads, result.Threads...)
+
+		if result.Pagination.CurrentPage >= result.Pagination.TotalPages {
+			break
+		}
+
+		page++
+		time.Sleep(1 * time.Second)
+	}
+
+	return threads, nil
+}
+
+func getXenForoPosts(threadID int) ([]XenForoPost, error) {
+	var posts []XenForoPost
+	page := 1
+
+	for {
+		resp, err := retryableRequest(func() (*resty.Response, error) {
+			return client.R().
+				SetHeader("XF-Api-Key", XenForoAPIKey).
+				SetHeader("XF-Api-User", XenForoAPIUser).
+				SetQueryParam("page", fmt.Sprintf("%d", page)).
+				Get(fmt.Sprintf("%s/threads/%d/posts", XenForoAPIURL, threadID))
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode() != 200 {
+			return nil, fmt.Errorf("XenForo API error: %s", resp.String())
+		}
+
+		var result struct {
+			Posts      []XenForoPost `json:"posts"`
+			Pagination struct {
+				CurrentPage int `json:"current_page"`
+				TotalPages  int `json:"total_pages"`
+			} `json:"pagination"`
+		}
+
+		err = json.Unmarshal(resp.Body(), &result)
+		if err != nil {
+			return nil, err
+		}
+
+		posts = append(posts, result.Posts...)
+
+		if result.Pagination.CurrentPage >= result.Pagination.TotalPages {
+			break
+		}
+
+		page++
+		time.Sleep(1 * time.Second)
+	}
+
+	return posts, nil
+}
+
+func getXenForoAttachments(threadID int) ([]XenForoAttachment, error) {
+	resp, err := retryableRequest(func() (*resty.Response, error) {
+		return client.R().
+			SetHeader("XF-Api-Key", XenForoAPIKey).
+			SetHeader("XF-Api-User", XenForoAPIUser).
+			Get(fmt.Sprintf("%s/threads/%d/attachments", XenForoAPIURL, threadID))
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode() != 200 {
+		return nil, fmt.Errorf("XenForo API error (attachments): %s", resp.String())
+	}
+
+	var result struct {
+		Attachments []XenForoAttachment `json:"attachments"`
+	}
+
+	err = json.Unmarshal(resp.Body(), &result)
+	return result.Attachments, err
+}
+
+func downloadAttachments(attachments []XenForoAttachment) {
+	for _, attachment := range attachments {
+		if dryRun {
+			log.Printf("    [DRY-RUN] Would download: %s", attachment.Filename)
+			continue
+		}
+
+		// Determine file extension and create directory
+		ext := strings.ToLower(filepath.Ext(attachment.Filename))
+		if ext == "" {
+			ext = ".unknown"
+		}
+		ext = strings.TrimPrefix(ext, ".")
+
+		dir := filepath.Join(AttachmentsDir, ext)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			log.Printf("    ✗ Failed to create directory %s: %v", dir, err)
+			continue
+		}
+
+		// Download file
+		filename := fmt.Sprintf("attachment_%d_%s", attachment.AttachmentID, attachment.Filename)
+		filePath := filepath.Join(dir, filename)
+
+		if _, err := os.Stat(filePath); err == nil {
+			log.Printf("    ⏭ Skipped (already exists): %s", filename)
+			continue
+		}
+
+		resp, err := client.R().
+			SetHeader("XF-Api-Key", XenForoAPIKey).
+			SetHeader("XF-Api-User", XenForoAPIUser).
+			SetOutput(filePath).
+			Get(attachment.ViewURL)
+
+		if err != nil || resp.StatusCode() != 200 {
+			log.Printf("    ✗ Failed to download %s: %v", filename, err)
+			continue
+		}
+
+		log.Printf("    ✓ Downloaded: %s", filename)
+		time.Sleep(500 * time.Millisecond) // Be nice to the server
+	}
+}
+
+func replaceAttachmentLinks(message string, attachments []XenForoAttachment) string {
+	for _, attachment := range attachments {
+		ext := strings.ToLower(filepath.Ext(attachment.Filename))
+		if ext == "" {
+			ext = ".unknown"
+		}
+		ext = strings.TrimPrefix(ext, ".")
+
+		filename := fmt.Sprintf("attachment_%d_%s", attachment.AttachmentID, attachment.Filename)
+		relativePath := fmt.Sprintf("./%s/%s", ext, filename)
+
+		// Determine if it's an image
+		isImage := ext == "png" || ext == "jpg" || ext == "jpeg" || ext == "gif" || ext == "webp"
+
+		// Replace BB-code with appropriate markdown
+		bbCode := fmt.Sprintf("[ATTACH=%d]", attachment.AttachmentID)
+		bbCodeFull := fmt.Sprintf("[ATTACH=full]%d[/ATTACH]", attachment.AttachmentID)
+
+		var markdownLink string
+		if isImage {
+			markdownLink = fmt.Sprintf("![%s](%s)", attachment.Filename, relativePath)
+		} else {
+			markdownLink = fmt.Sprintf("[%s](%s)", attachment.Filename, relativePath)
+		}
+
+		message = strings.ReplaceAll(message, bbCode, markdownLink)
+		message = strings.ReplaceAll(message, bbCodeFull, markdownLink)
+	}
+
+	// Log any remaining unhandled attach codes
+	remaining := regexp.MustCompile(`\[ATTACH[^]]*\]`).FindAllString(message, -1)
+	for _, code := range remaining {
+		log.Printf("    ⚠ Unhandled attachment code: %s", code)
+	}
+
+	return message
+}
+
+func createGitHubDiscussion(title, body, categoryID string) (string, int, error) {
+	var mutation struct {
+		CreateDiscussion struct {
+			Discussion struct {
+				ID     string
+				Number int
+			}
+		} `graphql:"createDiscussion(input: $input)"`
+	}
+
+	input := githubv4.CreateDiscussionInput{
+		RepositoryID: githubv4.ID(repositoryID),
+		Title:        githubv4.String(title),
+		Body:         githubv4.String(body),
+		CategoryID:   githubv4.ID(categoryID),
+	}
+
+	err := githubClient.Mutate(context.Background(), &mutation, input, nil)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return mutation.CreateDiscussion.Discussion.ID, mutation.CreateDiscussion.Discussion.Number, nil
+}
+
+func addGitHubComment(discussionID, body string) error {
+	var mutation struct {
+		AddDiscussionComment struct {
+			Comment struct {
+				ID githubv4.ID
+			}
+		} `graphql:"addDiscussionComment(input: $input)"`
+	}
+
+	input := githubv4.AddDiscussionCommentInput{
+		DiscussionID: githubv4.ID(discussionID),
+		Body:         githubv4.String(body),
+	}
+
+	return githubClient.Mutate(context.Background(), &mutation, input, nil)
+}
+
+func retryableRequest(req func() (*resty.Response, error)) (*resty.Response, error) {
+	for i := 0; i < MaxRetries; i++ {
+		resp, err := req()
+
+		// If successful or not a rate limit error, return
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode() != 429 {
+			return resp, nil
+		}
+
+		// Rate limited - exponential backoff
+		if i < MaxRetries-1 {
+			delay := time.Duration(math.Pow(2, float64(i))) * time.Second
+			log.Printf("    ⏳ Rate limited, retrying in %v...", delay)
+			time.Sleep(delay)
+		}
+	}
+
+	return nil, fmt.Errorf("max retries (%d) exceeded", MaxRetries)
+}
+
+func loadProgress() *MigrationProgress {
+	progress := &MigrationProgress{
+		CompletedThreads: []int{},
+		FailedThreads:    []int{},
+	}
+
+	data, err := os.ReadFile(ProgressFile)
+	if err != nil {
+		return progress
+	}
+
+	json.Unmarshal(data, progress)
+	return progress
+}
+
+func saveProgress() {
+	progress.LastUpdated = time.Now().Unix()
+	data, _ := json.MarshalIndent(progress, "", "  ")
+	os.WriteFile(ProgressFile, data, 0644)
+}
+
+func filterCompletedThreads(threads []XenForoThread) []XenForoThread {
+	completed := make(map[int]bool)
+	for _, id := range progress.CompletedThreads {
+		completed[id] = true
+	}
+
+	var filtered []XenForoThread
+	for _, thread := range threads {
+		// Skip if already completed
+		if completed[thread.ThreadID] {
+			continue
+		}
+		// Include threads that haven't been processed yet
+		// (either newer than LastThreadID or were skipped before)
+		filtered = append(filtered, thread)
+	}
+
+	return filtered
+}
+
+func printSummary() {
+	fmt.Println("\n" + strings.Repeat("=", 50))
+	fmt.Println("Migration Summary")
+	fmt.Println(strings.Repeat("=", 50))
+	fmt.Printf("Completed threads: %d\n", len(progress.CompletedThreads))
+	fmt.Printf("Failed threads: %d\n", len(progress.FailedThreads))
+
+	if len(progress.FailedThreads) > 0 {
+		fmt.Println("\nFailed thread IDs:")
+		for _, id := range progress.FailedThreads {
+			fmt.Printf("  - %d\n", id)
+		}
+	}
+
+	if dryRun {
+		fmt.Println("\n[DRY-RUN MODE] No actual changes were made")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,527 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestConvertBBCodeToMarkdown tests the BB-code to Markdown conversion
+func TestConvertBBCodeToMarkdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Basic formatting
+		{
+			name:     "Bold text",
+			input:    "This is [b]bold text[/b].",
+			expected: "This is **bold text**.",
+		},
+		{
+			name:     "Italic text",
+			input:    "This is [i]italic text[/i].",
+			expected: "This is *italic text*.",
+		},
+		{
+			name:     "Underline text",
+			input:    "This is [u]underlined text[/u].",
+			expected: "This is <u>underlined text</u>.",
+		},
+		{
+			name:     "Strikethrough with [s]",
+			input:    "This is [s]strikethrough text[/s].",
+			expected: "This is ~~strikethrough text~~.",
+		},
+		{
+			name:     "Strikethrough with [strike]",
+			input:    "This is [strike]strikethrough text[/strike].",
+			expected: "This is ~~strikethrough text~~.",
+		},
+
+		// URLs
+		{
+			name:     "URL with text",
+			input:    "Check out [url=https://example.com]this link[/url]!",
+			expected: "Check out [this link](https://example.com)!",
+		},
+		{
+			name:     "URL without text",
+			input:    "Visit [url]https://example.com[/url]",
+			expected: "Visit [https://example.com](https://example.com)",
+		},
+		{
+			name:     "URL with quotes",
+			input:    `Visit [url="https://example.com"]this link[/url]`,
+			expected: "Visit [this link](https://example.com)",
+		},
+
+		// Images
+		{
+			name:     "Image",
+			input:    "Here's an image: [img]https://example.com/image.png[/img]",
+			expected: "Here's an image: ![](https://example.com/image.png)",
+		},
+
+		// Quotes
+		{
+			name:     "Simple quote",
+			input:    "[quote]This is a quoted text[/quote]",
+			expected: "> This is a quoted text\n",
+		},
+		{
+			name:     "Quote with attribution",
+			input:    `[quote="John Doe"]This is John's quote[/quote]`,
+			expected: "> **John Doe said:**\n> This is John's quote\n",
+		},
+		{
+			name:     "Quote with attribution and extra params",
+			input:    `[quote="John Doe, post: 123"]This is John's quote[/quote]`,
+			expected: "> **John Doe said:**\n> This is John's quote\n",
+		},
+		{
+			name:     "Multi-line quote",
+			input:    "[quote]Line 1\nLine 2\nLine 3[/quote]",
+			expected: "> Line 1\n> Line 2\n> Line 3\n",
+		},
+
+		// Code blocks
+		{
+			name:     "Inline code",
+			input:    "Use [code]fmt.Println()[/code] to print.",
+			expected: "Use \n```\nfmt.Println()\n```\n to print.",
+		},
+		{
+			name:     "Multi-line code",
+			input:    "[code]\nfunc main() {\n    fmt.Println(\"Hello\")\n}\n[/code]",
+			expected: "\n```\nfunc main() {\n    fmt.Println(\"Hello\")\n}\n```\n",
+		},
+
+		// Spoilers
+		{
+			name:     "Block spoiler",
+			input:    "[spoiler]Hidden content[/spoiler]",
+			expected: "<details><summary>Spoiler</summary>\n\nHidden content\n\n</details>",
+		},
+		{
+			name:     "Block spoiler with title",
+			input:    `[spoiler="Plot twist"]The butler did it[/spoiler]`,
+			expected: "<details><summary>Spoiler</summary>\n\nThe butler did it\n\n</details>",
+		},
+		{
+			name:     "Inline spoiler",
+			input:    "The answer is [ispoiler]42[/ispoiler]!",
+			expected: "The answer is ||42||!",
+		},
+
+		// Lists
+		{
+			name:     "Simple list",
+			input:    "[list]\n[*]Item 1\n[*]Item 2\n[*]Item 3\n[/list]",
+			expected: "\n- Item 1\n- Item 2\n- Item 3\n",
+		},
+		{
+			name:     "Numbered list",
+			input:    "[list=1]\n[*]First\n[*]Second\n[/list]",
+			expected: "\n- First\n- Second\n",
+		},
+
+		// Media
+		{
+			name:     "Media embed",
+			input:    "[media=youtube]dQw4w9WgXcQ[/media]",
+			expected: "[youtube](dQw4w9WgXcQ)",
+		},
+
+		// Center
+		{
+			name:     "Center alignment",
+			input:    "[center]Centered text[/center]",
+			expected: "<center>Centered text</center>",
+		},
+
+		// Color, size, font removal
+		{
+			name:     "Color tag removal",
+			input:    "[color=red]Red text[/color]",
+			expected: "Red text",
+		},
+		{
+			name:     "Size tag removal",
+			input:    "[size=20]Large text[/size]",
+			expected: "Large text",
+		},
+		{
+			name:     "Font tag removal",
+			input:    "[font=Arial]Arial text[/font]",
+			expected: "Arial text",
+		},
+
+		// Complex nested tags
+		{
+			name:     "Nested formatting",
+			input:    "[b][i]Bold and italic[/i][/b]",
+			expected: "***Bold and italic***",
+		},
+		{
+			name:     "Quote with formatting",
+			input:    `[quote="User"][b]Important:[/b] Read this[/quote]`,
+			expected: "> **User said:**\n> **Important:** Read this\n",
+		},
+
+		// Edge cases
+		{
+			name:     "Empty tags",
+			input:    "[b][/b]",
+			expected: "****",
+		},
+		{
+			name:     "Unclosed tags",
+			input:    "[b]Bold text",
+			expected: "Bold text",
+		},
+		{
+			name:     "Unknown tags",
+			input:    "[unknown]Content[/unknown]",
+			expected: "Content",
+		},
+		{
+			name:     "Multiple newlines cleanup",
+			input:    "Line 1\n\n\n\nLine 2",
+			expected: "Line 1\n\nLine 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertBBCodeToMarkdown(tt.input)
+			if result != tt.expected {
+				t.Errorf("\nInput:    %q\nExpected: %q\nGot:      %q", tt.input, tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestFormatMessage tests the message formatting with metadata
+func TestFormatMessage(t *testing.T) {
+	username := "JohnDoe"
+	postDate := int64(1642353000) // 2022-01-16 17:10:00 UTC
+	threadID := 12345
+	content := "This is the message content."
+
+	expected := `---
+Author: JohnDoe
+Posted: 2022-01-16 17:10:00 UTC
+Original Thread ID: 12345
+---
+
+This is the message content.`
+
+	result := formatMessage(username, postDate, threadID, content)
+	if result != expected {
+		t.Errorf("\nExpected:\n%s\n\nGot:\n%s", expected, result)
+	}
+}
+
+// TestReplaceAttachmentLinks tests attachment link replacement
+func TestReplaceAttachmentLinks(t *testing.T) {
+	attachments := []XenForoAttachment{
+		{AttachmentID: 123, Filename: "screenshot.png", ViewURL: "https://example.com/attach/123"},
+		{AttachmentID: 456, Filename: "document.pdf", ViewURL: "https://example.com/attach/456"},
+		{AttachmentID: 789, Filename: "archive.zip", ViewURL: "https://example.com/attach/789"},
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Image attachment",
+			input:    "Check this screenshot: [ATTACH=123]",
+			expected: "Check this screenshot: ![screenshot.png](./png/attachment_123_screenshot.png)",
+		},
+		{
+			name:     "PDF attachment",
+			input:    "Download the document: [ATTACH=456]",
+			expected: "Download the document: [document.pdf](./pdf/attachment_456_document.pdf)",
+		},
+		{
+			name:     "Full format attachment",
+			input:    "See image: [ATTACH=full]123[/ATTACH]",
+			expected: "See image: ![screenshot.png](./png/attachment_123_screenshot.png)",
+		},
+		{
+			name:     "Multiple attachments",
+			input:    "[ATTACH=123] and [ATTACH=456]",
+			expected: "![screenshot.png](./png/attachment_123_screenshot.png) and [document.pdf](./pdf/attachment_456_document.pdf)",
+		},
+		{
+			name:     "Unknown attachment",
+			input:    "Missing: [ATTACH=999]",
+			expected: "Missing: [ATTACH=999]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := replaceAttachmentLinks(tt.input, attachments)
+			if result != tt.expected {
+				t.Errorf("\nExpected: %q\nGot:      %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestProgressTracking tests save and load progress functionality
+func TestProgressTracking(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "godisc-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Override progress file location
+	oldProgressFile := ProgressFile
+	testProgressFile := filepath.Join(tempDir, "test_progress.json")
+	defer func() {
+		ProgressFile = oldProgressFile
+	}()
+
+	// Test saving progress
+	testProgress := &MigrationProgress{
+		LastThreadID:     100,
+		CompletedThreads: []int{1, 2, 3, 100},
+		FailedThreads:    []int{50},
+		LastUpdated:      time.Now().Unix(),
+	}
+
+	// Save test progress
+	data, _ := json.MarshalIndent(testProgress, "", "  ")
+	err = os.WriteFile(testProgressFile, data, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test loading progress
+	loadedData, err := os.ReadFile(testProgressFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var loadedProgress MigrationProgress
+	err = json.Unmarshal(loadedData, &loadedProgress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify loaded data
+	if loadedProgress.LastThreadID != testProgress.LastThreadID {
+		t.Errorf("LastThreadID mismatch: expected %d, got %d", testProgress.LastThreadID, loadedProgress.LastThreadID)
+	}
+
+	if len(loadedProgress.CompletedThreads) != len(testProgress.CompletedThreads) {
+		t.Errorf("CompletedThreads length mismatch: expected %d, got %d",
+			len(testProgress.CompletedThreads), len(loadedProgress.CompletedThreads))
+	}
+
+	if len(loadedProgress.FailedThreads) != len(testProgress.FailedThreads) {
+		t.Errorf("FailedThreads length mismatch: expected %d, got %d",
+			len(testProgress.FailedThreads), len(loadedProgress.FailedThreads))
+	}
+}
+
+// TestFilterCompletedThreads tests the thread filtering logic
+func TestFilterCompletedThreads(t *testing.T) {
+	// Set up test progress
+	progress = &MigrationProgress{
+		LastThreadID:     50,
+		CompletedThreads: []int{10, 20, 30, 60, 70},
+		FailedThreads:    []int{},
+	}
+
+	threads := []XenForoThread{
+		{ThreadID: 10, Title: "Thread 10"}, // Completed
+		{ThreadID: 20, Title: "Thread 20"}, // Completed
+		{ThreadID: 25, Title: "Thread 25"}, // Not completed, less than LastThreadID
+		{ThreadID: 30, Title: "Thread 30"}, // Completed
+		{ThreadID: 40, Title: "Thread 40"}, // Not completed, less than LastThreadID
+		{ThreadID: 60, Title: "Thread 60"}, // Completed
+		{ThreadID: 70, Title: "Thread 70"}, // Completed
+		{ThreadID: 80, Title: "Thread 80"}, // Not completed, greater than LastThreadID
+		{ThreadID: 90, Title: "Thread 90"}, // Not completed, greater than LastThreadID
+	}
+
+	filtered := filterCompletedThreads(threads)
+
+	// Expected: threads 25, 40, 80, 90 (not completed)
+	expectedIDs := []int{25, 40, 80, 90}
+
+	if len(filtered) != len(expectedIDs) {
+		t.Errorf("Expected %d threads, got %d", len(expectedIDs), len(filtered))
+	}
+
+	for i, thread := range filtered {
+		if i < len(expectedIDs) && thread.ThreadID != expectedIDs[i] {
+			t.Errorf("Expected thread ID %d at position %d, got %d", expectedIDs[i], i, thread.ThreadID)
+		}
+	}
+}
+
+// TestExtensionDetection tests file extension detection for attachments
+func TestExtensionDetection(t *testing.T) {
+	tests := []struct {
+		filename string
+		expected string
+		isImage  bool
+	}{
+		{"image.png", "png", true},
+		{"photo.jpg", "jpg", true},
+		{"photo.jpeg", "jpeg", true},
+		{"animation.gif", "gif", true},
+		{"modern.webp", "webp", true},
+		{"document.pdf", "pdf", false},
+		{"archive.zip", "zip", false},
+		{"code.txt", "txt", false},
+		{"noextension", "unknown", false},
+		{"UPPERCASE.PNG", "png", true},
+		{"multiple.dots.in.name.pdf", "pdf", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			ext := strings.ToLower(filepath.Ext(tt.filename))
+			if ext == "" {
+				ext = ".unknown"
+			}
+			ext = strings.TrimPrefix(ext, ".")
+
+			if ext != tt.expected {
+				t.Errorf("Expected extension %q for %q, got %q", tt.expected, tt.filename, ext)
+			}
+
+			isImage := ext == "png" || ext == "jpg" || ext == "jpeg" || ext == "gif" || ext == "webp"
+			if isImage != tt.isImage {
+				t.Errorf("Expected isImage=%v for %q, got %v", tt.isImage, tt.filename, isImage)
+			}
+		})
+	}
+}
+
+// BenchmarkConvertBBCodeToMarkdown benchmarks the BB-code conversion
+func BenchmarkConvertBBCodeToMarkdown(b *testing.B) {
+	// Create a complex input with various BB codes
+	input := `[b]Bold text[/b] and [i]italic[/i] with [url=https://example.com]a link[/url].
+[quote="User"]This is a quoted text with [b]formatting[/b].[/quote]
+[code]
+func example() {
+    return "Hello, World!"
+}
+[/code]
+[spoiler]Hidden content[/spoiler]
+[list]
+[*]Item 1
+[*]Item 2
+[*]Item 3
+[/list]`
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = convertBBCodeToMarkdown(input)
+	}
+}
+
+// BenchmarkReplaceAttachmentLinks benchmarks attachment replacement
+func BenchmarkReplaceAttachmentLinks(b *testing.B) {
+	attachments := make([]XenForoAttachment, 100)
+	for i := 0; i < 100; i++ {
+		attachments[i] = XenForoAttachment{
+			AttachmentID: i,
+			Filename:     fmt.Sprintf("file%d.png", i),
+			ViewURL:      fmt.Sprintf("https://example.com/attach/%d", i),
+		}
+	}
+
+	input := "Text with [ATTACH=0] and [ATTACH=50] and [ATTACH=99] attachments."
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = replaceAttachmentLinks(input, attachments)
+	}
+}
+
+// TestEdgeCases tests various edge cases
+func TestEdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		testFunc func(t *testing.T)
+	}{
+		{
+			name: "Empty input",
+			testFunc: func(t *testing.T) {
+				result := convertBBCodeToMarkdown("")
+				if result != "" {
+					t.Errorf("Expected empty string, got %q", result)
+				}
+			},
+		},
+		{
+			name: "Only whitespace",
+			testFunc: func(t *testing.T) {
+				result := convertBBCodeToMarkdown("   \n\t  ")
+				if result != "" {
+					t.Errorf("Expected empty string after trim, got %q", result)
+				}
+			},
+		},
+		{
+			name: "Malformed BB-code",
+			testFunc: func(t *testing.T) {
+				input := "[b[i]text[/i]"
+				result := convertBBCodeToMarkdown(input)
+				// Should handle gracefully without panic
+				if strings.Contains(result, "[b[") {
+					t.Errorf("Malformed tag not cleaned up: %q", result)
+				}
+			},
+		},
+		{
+			name: "Unicode handling",
+			testFunc: func(t *testing.T) {
+				input := "[b]Hello 世界 🌍[/b]"
+				expected := "**Hello 世界 🌍**"
+				result := convertBBCodeToMarkdown(input)
+				if result != expected {
+					t.Errorf("Unicode not handled correctly.\nExpected: %q\nGot: %q", expected, result)
+				}
+			},
+		},
+		{
+			name: "Very long input",
+			testFunc: func(t *testing.T) {
+				// Generate a very long string
+				var sb strings.Builder
+				for i := 0; i < 1000; i++ {
+					sb.WriteString(fmt.Sprintf("[b]Line %d[/b]\n", i))
+				}
+				input := sb.String()
+				result := convertBBCodeToMarkdown(input)
+
+				// Should complete without timeout or panic
+				if !strings.Contains(result, "**Line 999**") {
+					t.Error("Long input not processed correctly")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.testFunc)
+	}
+}

--- a/testdata/sample_bbcode.txt
+++ b/testdata/sample_bbcode.txt
@@ -1,0 +1,25 @@
+[b]Bold text[/b] and [i]italic text[/i] with [url=https://example.com]a link[/url].
+
+[quote="User"]This is a quoted message with [b]bold[/b] formatting.[/quote]
+
+[code]
+func example() {
+    return "Hello, World!"
+}
+[/code]
+
+[spoiler]This is hidden content[/spoiler]
+
+[list]
+[*]First item
+[*]Second item
+[*]Third item
+[/list]
+
+Here's an image: [img]https://example.com/image.png[/img]
+
+And an attachment: [ATTACH=123]
+
+[center]Centered text[/center]
+
+[color=red]Red text[/color] and [size=20]large text[/size].


### PR DESCRIPTION
- Introduced main application logic for migrating threads, posts, and attachments from XenForo to GitHub Discussions.
- Implemented BB-code to Markdown conversion with support for various formatting features.
- Added retry logic for API requests with exponential backoff.
- Included progress tracking and dry-run mode for safe testing.
- Created comprehensive test suite for validation of functionality and performance.
- Established configuration options for API credentials and migration settings.
- Set up GitHub Actions for continuous integration and testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line tool for migrating XenForo 2 forum threads and posts to GitHub Discussions, supporting BBCode to Markdown conversion, attachment handling, progress tracking, and resumable migrations.
  - Added dry-run, verbose logging, and pre-flight checks for safer and more transparent migrations.

- **Documentation**
  - Completely rewrote and expanded the README with detailed setup, usage, configuration, troubleshooting, and contribution guidelines.

- **Tests**
  - Added comprehensive unit and integration tests for API interactions, migration workflows, BBCode conversion, attachment handling, and progress tracking.
  - Included performance benchmarks and edge case tests for robustness.

- **Chores**
  - Added configuration files for consistent code style, Git attributes, and ignore rules for multiple platforms and IDEs.
  - Introduced a GitHub Actions workflow for automated testing and building.
  - Added Go module definition and sample BBCode test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->