### PR TITLE
Update dependencies and enhance test synchronization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,4 +57,4 @@ jobs:
         run: go build -v -o xenforo-to-gh-discussions .
 
       - name: Test binary execution
-        run: ./xenforo-to-gh-discussions --help || true
+        run: ./xenforo-to-gh-discussions --help

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/exileum/xenforo-to-gh-discussions
 go 1.24
 
 require (
+	github.com/dlclark/regexp2 v1.11.5
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7
 	golang.org/x/oauth2 v0.30.0
@@ -10,5 +11,5 @@ require (
 
 require (
 	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
-	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/net v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,13 @@
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7 h1:cYCy18SHPKRkvclm+pWm1Lk4YrREb4IOIb/YdFO0p2M=
 github.com/shurcooL/githubv4 v0.0.0-20240727222349-48295856cce7/go.mod h1:zqMwyHmnN/eDOZOdiTohqIUKUrTFX62PNlu7IJdu0q8=
 github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
 github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
+golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
 golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
 golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=

--- a/main_test.go
+++ b/main_test.go
@@ -207,6 +207,55 @@ func TestConvertBBCodeToMarkdown(t *testing.T) {
 	}
 }
 
+// TestMarkdownLinkPreservation tests that markdown links are preserved during BB-code cleanup
+func TestMarkdownLinkPreservation(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Markdown link after BB-code",
+			input:    "[b]bold text[/b] [link](https://example.com)",
+			expected: "**bold text** [link](https://example.com)",
+		},
+		{
+			name:     "Multiple identical BB-codes with markdown link",
+			input:    "[b]first[/b] [b]second[/b] [link](url) [b]third[/b]",
+			expected: "**first** **second** [link](url) **third**",
+		},
+		{
+			name:     "Unknown BB-code with markdown link",
+			input:    "[unknown]text[/unknown] [link](url)",
+			expected: "text [link](url)",
+		},
+		{
+			name:     "Mixed BB-codes and markdown links",
+			input:    "[i]italic[/i] [link1](url1) [b]bold[/b] [link2](url2) [unknown]removed[/unknown]",
+			expected: "*italic* [link1](url1) **bold** [link2](url2) removed",
+		},
+		{
+			name:     "ATTACH tag preserved with markdown link",
+			input:    "[ATTACH=123] [link](url) [ATTACH=full]456[/ATTACH]",
+			expected: "[ATTACH=123] [link](url) [ATTACH=full]456[/ATTACH]",
+		},
+		{
+			name:     "Edge case: bracket in URL",
+			input:    "[b]text[/b] [link](https://example.com/page[1])",
+			expected: "**text** [link](https://example.com/page[1])",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertBBCodeToMarkdown(tt.input)
+			if result != tt.expected {
+				t.Errorf("\nInput:    %q\nExpected: %q\nGot:      %q", tt.input, tt.expected, result)
+			}
+		})
+	}
+}
+
 // TestFormatMessage tests the message formatting with metadata
 func TestFormatMessage(t *testing.T) {
 	username := "JohnDoe"


### PR DESCRIPTION
- Added `github.com/dlclark/regexp2` as a new dependency for improved BB-code cleanup.
- Updated `golang.org/x/net` from v0.38.0 to v0.41.0.
- Improved synchronization in `TestConcurrentOperations` to prevent race conditions.
- Added `TestMarkdownLinkPreservation` to ensure markdown links are preserved during BB-code cleanup.