### PR TITLE
fix: remove redundant cd command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,6 @@ jobs:
           cd dist && tar -czf "${ARCHIVE_NAME}.tar.gz" "${BINARY_NAME}"
 
           # Create checksums
-          cd dist
           sha256sum "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"
 
       - name: Upload artifacts


### PR DESCRIPTION
- Eliminated unnecessary 'cd dist' command before checksum creation in the release workflow, streamlining the process.