### PR TITLE
docs: update sample BBCode test data with user mentions and email handling guidance

### DIFF
--- a/test/testdata/sample_bbcode.txt
+++ b/test/testdata/sample_bbcode.txt
@@ -23,3 +23,7 @@ And an attachment: [ATTACH=123]
 [center]Centered text[/center]
 
 [color=red]Red text[/color] and [size=20]large text[/size].
+
+Thanks @admin for the help! Also ping @moderator-user and @user_name.
+
+But don't convert emails like contact@example.com or user@domain.org.


### PR DESCRIPTION
- Added user mentions for @admin, @moderator-user, and @user_name to the sample BBCode.
- Included a note to prevent conversion of email addresses like contact@example.com and user@domain.org.

These updates enhance the clarity of the sample data for testing purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User mentions (e.g., @username) in messages are now displayed in bold to avoid triggering platform notifications.
  * BBCode quotes with attribution are now converted to markdown blockquotes with an attribution line.
  * Improved support for nested quotes in message formatting.

* **Bug Fixes**
  * Email addresses containing "@" are no longer incorrectly converted as user mentions.

* **Tests**
  * Added tests for user mention conversion and enhanced quote conversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->