### PR TITLE
feat(github): add rate limiting and retry mechanisms for GitHub API calls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -358,6 +358,11 @@ export GITHUB_TOKEN="your_github_token"
 export GITHUB_REPO="owner/repository"
 export GITHUB_CATEGORY_ID="DIC_kwDOxxxxxxxx" # GitHub Discussion category ID to migrate to
 
+# GitHub API Rate Limiting (Optional)
+export GITHUB_RATE_LIMIT_DELAY="1s" # Delay between GitHub API calls
+export GITHUB_MAX_RETRIES="5" # Maximum retries for rate limited requests
+export GITHUB_RETRY_BACKOFF_MULTIPLE="2" # Exponential backoff multiplier (seconds)
+
 # Migration Settings
 export MAX_RETRIES="3"
 export ATTACHMENTS_DIR="./attachments"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ export GITHUB_TOKEN="your_github_token"
 export GITHUB_REPO="owner/repository"
 export GITHUB_CATEGORY_ID="DIC_kwDOxxxxxxxx" # GitHub Discussion category ID to migrate to
 
+# GitHub API Rate Limiting (Optional)
+export GITHUB_RATE_LIMIT_DELAY="1s" # Delay between GitHub API calls
+export GITHUB_MAX_RETRIES="5" # Maximum retries for rate limited requests
+export GITHUB_RETRY_BACKOFF_MULTIPLE="2" # Exponential backoff multiplier (seconds)
+
 # Migration Settings
 export MAX_RETRIES="3"
 export ATTACHMENTS_DIR="./attachments"

--- a/internal/bbcode/bbcode_test.go
+++ b/internal/bbcode/bbcode_test.go
@@ -113,6 +113,16 @@ func TestAtMentionConversion(t *testing.T) {
 			expected: "Contact user@example.com for help",
 		},
 		{
+			name:     "Purely numeric username should not be converted",
+			input:    "Check thread @123 for details",
+			expected: "Check thread @123 for details",
+		},
+		{
+			name:     "Complex email patterns should not be converted",
+			input:    "Reach out to test.user+tag@sub.example.co.uk",
+			expected: "Reach out to test.user+tag@sub.example.co.uk",
+		},
+		{
 			name:     "Mixed content",
 			input:    "Thanks @admin for [b]fixing[/b] the issue!",
 			expected: "Thanks **admin** for **fixing** the issue!",

--- a/internal/bbcode/processor.go
+++ b/internal/bbcode/processor.go
@@ -91,19 +91,19 @@ func (p *MessageProcessor) convertAtMentions(content string) string {
 	// Enhanced regex: require at least one alphabetic character and use word boundaries
 	// This prevents purely numeric usernames and ensures proper boundaries
 	mentionRe := regexp.MustCompile(`@([a-zA-Z0-9_-]*[a-zA-Z]+[a-zA-Z0-9_-]*)\b`)
-	
+
 	// More comprehensive email pattern to avoid false positives
 	emailRe := regexp.MustCompile(`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
-	
+
 	// Find all email matches first to exclude them
 	emailMatches := emailRe.FindAllStringIndex(content, -1)
-	
+
 	// Use ReplaceAllStringFunc with position tracking for efficiency
 	result := mentionRe.ReplaceAllStringFunc(content, func(match string) string {
 		// Get the match position using FindStringIndex
 		matchIndices := mentionRe.FindAllStringIndex(content, -1)
 		var matchStart, matchEnd int
-		
+
 		// Find the current match position by comparing the match string
 		for _, indices := range matchIndices {
 			if content[indices[0]:indices[1]] == match {
@@ -111,7 +111,7 @@ func (p *MessageProcessor) convertAtMentions(content string) string {
 				break
 			}
 		}
-		
+
 		// Check if this @ symbol is part of an email by checking overlap with email matches
 		for _, emailIndex := range emailMatches {
 			emailStart, emailEnd := emailIndex[0], emailIndex[1]
@@ -120,16 +120,16 @@ func (p *MessageProcessor) convertAtMentions(content string) string {
 				return match
 			}
 		}
-		
+
 		// Extract username from the match
 		parts := mentionRe.FindStringSubmatch(match)
 		if len(parts) < 2 {
 			return match
 		}
 		username := parts[1]
-		
+
 		return "**" + username + "**"
 	})
-	
+
 	return result
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,11 +21,14 @@ type XenForoConfig struct {
 }
 
 type GitHubConfig struct {
-	Token            string
-	Repository       string
-	Categories       map[int]string // Kept for backward compatibility
-	XenForoNodeID    int            // Single source category
-	GitHubCategoryID string         // Single target category
+	Token                string
+	Repository           string
+	Categories           map[int]string // Kept for backward compatibility
+	XenForoNodeID        int            // Single source category
+	GitHubCategoryID     string         // Single target category
+	RateLimitDelay       time.Duration  // Delay between API calls
+	MaxRetries           int            // Maximum retries for rate limited requests
+	RetryBackoffMultiple int            // Multiplier for exponential backoff (seconds)
 }
 
 type MigrationConfig struct {
@@ -51,11 +54,14 @@ func New() *Config {
 			NodeID:  getEnvIntOrDefault("XENFORO_NODE_ID", 1),
 		},
 		GitHub: GitHubConfig{
-			Token:            getEnvOrDefault("GITHUB_TOKEN", "your_github_token"),
-			Repository:       getEnvOrDefault("GITHUB_REPO", "your_username/your_repo"),
-			Categories:       make(map[int]string),
-			XenForoNodeID:    getEnvIntOrDefault("XENFORO_NODE_ID", 1),
-			GitHubCategoryID: getEnvOrDefault("GITHUB_CATEGORY_ID", "DIC_kwDOxxxxxxxx"),
+			Token:                getEnvOrDefault("GITHUB_TOKEN", "your_github_token"),
+			Repository:           getEnvOrDefault("GITHUB_REPO", "your_username/your_repo"),
+			Categories:           make(map[int]string),
+			XenForoNodeID:        getEnvIntOrDefault("XENFORO_NODE_ID", 1),
+			GitHubCategoryID:     getEnvOrDefault("GITHUB_CATEGORY_ID", "DIC_kwDOxxxxxxxx"),
+			RateLimitDelay:       getEnvDurationOrDefault("GITHUB_RATE_LIMIT_DELAY", 1*time.Second),
+			MaxRetries:           getEnvIntOrDefault("GITHUB_MAX_RETRIES", 5),
+			RetryBackoffMultiple: getEnvIntOrDefault("GITHUB_RETRY_BACKOFF_MULTIPLE", 2),
 		},
 		Migration: MigrationConfig{
 			MaxRetries:   getEnvIntOrDefault("MAX_RETRIES", 3),

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -104,6 +104,19 @@ func (c *Config) validateGitHub() error {
 		return fmt.Errorf("GitHub repository must be in format 'owner/repo'")
 	}
 
+	// Validate rate limiting configuration
+	if c.GitHub.RateLimitDelay < 0 {
+		return fmt.Errorf("GitHub rate limit delay cannot be negative")
+	}
+
+	if c.GitHub.MaxRetries < 0 {
+		return fmt.Errorf("GitHub max retries cannot be negative")
+	}
+
+	if c.GitHub.RetryBackoffMultiple <= 0 {
+		return fmt.Errorf("GitHub retry backoff multiple must be positive")
+	}
+
 	// Validate category configuration using shared logic
 	validator := &basicConfigValidator{}
 	if err := ValidateCategoryConfiguration(c, validator); err != nil {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewClient(t *testing.T) {
@@ -44,7 +45,7 @@ func TestNewClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := NewClient(tt.token)
+			client, err := NewClient(tt.token, 1*time.Second, 3, 2)
 
 			if tt.shouldErr {
 				if err == nil {
@@ -71,7 +72,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestClientRepositoryID(t *testing.T) {
-	client, err := NewClient("test_github_token_for_testing_only")
+	client, err := NewClient("test_github_token_for_testing_only", 1*time.Second, 3, 2)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/internal/github/mutations.go
+++ b/internal/github/mutations.go
@@ -25,31 +25,43 @@ func (c *Client) CreateDiscussion(title, body, categoryID string) (*DiscussionRe
 		return nil, fmt.Errorf("categoryID cannot be empty")
 	}
 
-	var mutation struct {
-		CreateDiscussion struct {
-			Discussion struct {
-				ID     string
-				Number int
-			}
-		} `graphql:"createDiscussion(input: $input)"`
-	}
+	var result *DiscussionResult
 
-	input := githubv4.CreateDiscussionInput{
-		RepositoryID: githubv4.ID(c.repositoryID),
-		Title:        githubv4.String(title),
-		Body:         githubv4.String(body),
-		CategoryID:   githubv4.ID(categoryID),
-	}
+	err := c.executeWithRetry(func() error {
+		var mutation struct {
+			CreateDiscussion struct {
+				Discussion struct {
+					ID     string
+					Number int
+				}
+			} `graphql:"createDiscussion(input: $input)"`
+		}
 
-	err := c.client.Mutate(context.Background(), &mutation, input, nil)
+		input := githubv4.CreateDiscussionInput{
+			RepositoryID: githubv4.ID(c.repositoryID),
+			Title:        githubv4.String(title),
+			Body:         githubv4.String(body),
+			CategoryID:   githubv4.ID(categoryID),
+		}
+
+		err := c.client.Mutate(context.Background(), &mutation, input, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create discussion %q in category %q: %w", title, categoryID, err)
+		}
+
+		result = &DiscussionResult{
+			ID:     mutation.CreateDiscussion.Discussion.ID,
+			Number: mutation.CreateDiscussion.Discussion.Number,
+		}
+
+		return nil
+	})
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to create discussion %q in category %q: %w", title, categoryID, err)
+		return nil, err
 	}
 
-	return &DiscussionResult{
-		ID:     mutation.CreateDiscussion.Discussion.ID,
-		Number: mutation.CreateDiscussion.Discussion.Number,
-	}, nil
+	return result, nil
 }
 
 func (c *Client) AddComment(discussionID, body string) error {
@@ -61,23 +73,25 @@ func (c *Client) AddComment(discussionID, body string) error {
 		return fmt.Errorf("comment body cannot be empty")
 	}
 
-	var mutation struct {
-		AddDiscussionComment struct {
-			Comment struct {
-				ID githubv4.ID
-			}
-		} `graphql:"addDiscussionComment(input: $input)"`
-	}
+	return c.executeWithRetry(func() error {
+		var mutation struct {
+			AddDiscussionComment struct {
+				Comment struct {
+					ID githubv4.ID
+				}
+			} `graphql:"addDiscussionComment(input: $input)"`
+		}
 
-	input := githubv4.AddDiscussionCommentInput{
-		DiscussionID: githubv4.ID(discussionID),
-		Body:         githubv4.String(body),
-	}
+		input := githubv4.AddDiscussionCommentInput{
+			DiscussionID: githubv4.ID(discussionID),
+			Body:         githubv4.String(body),
+		}
 
-	err := c.client.Mutate(context.Background(), &mutation, input, nil)
-	if err != nil {
-		return fmt.Errorf("failed to add comment to discussion %q: %w", discussionID, err)
-	}
+		err := c.client.Mutate(context.Background(), &mutation, input, nil)
+		if err != nil {
+			return fmt.Errorf("failed to add comment to discussion %q: %w", discussionID, err)
+		}
 
-	return nil
+		return nil
+	})
 }

--- a/internal/migration/migrator.go
+++ b/internal/migration/migrator.go
@@ -37,7 +37,12 @@ func (m *Migrator) Run() error {
 	var githubClient *github.Client
 	if !m.config.Migration.DryRun {
 		var err error
-		githubClient, err = github.NewClient(m.config.GitHub.Token)
+		githubClient, err = github.NewClient(
+			m.config.GitHub.Token,
+			m.config.GitHub.RateLimitDelay,
+			m.config.GitHub.MaxRetries,
+			m.config.GitHub.RetryBackoffMultiple,
+		)
 		if err != nil {
 			return fmt.Errorf("failed to initialize GitHub client: %w", err)
 		}

--- a/test/integration/migration_test.go
+++ b/test/integration/migration_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/exileum/xenforo-to-gh-discussions/internal/config"
 	"github.com/exileum/xenforo-to-gh-discussions/internal/migration"
@@ -26,9 +27,12 @@ func TestMigrationIntegration(t *testing.T) {
 			NodeID:  1,
 		},
 		GitHub: config.GitHubConfig{
-			Token:      "test_token",
-			Repository: "test/repo",
-			Categories: map[int]string{1: "DIC_kwDOtest123"},
+			Token:                "test_token",
+			Repository:           "test/repo",
+			Categories:           map[int]string{1: "DIC_kwDOtest123"},
+			RateLimitDelay:       1 * time.Second,
+			MaxRetries:           3,
+			RetryBackoffMultiple: 2,
 		},
 		Migration: config.MigrationConfig{
 			MaxRetries:   3,
@@ -37,7 +41,8 @@ func TestMigrationIntegration(t *testing.T) {
 			ProgressFile: filepath.Join(tempDir, "progress.json"),
 		},
 		Filesystem: config.FilesystemConfig{
-			AttachmentsDir: filepath.Join(tempDir, "attachments"),
+			AttachmentsDir:           filepath.Join(tempDir, "attachments"),
+			AttachmentRateLimitDelay: 500 * time.Millisecond,
 		},
 	}
 
@@ -74,9 +79,12 @@ func TestEndToEndWithMocks(t *testing.T) {
 			NodeID:  1,
 		},
 		GitHub: config.GitHubConfig{
-			Token:      "test_token",
-			Repository: "test/repo",
-			Categories: map[int]string{1: "DIC_kwDOtest123"},
+			Token:                "test_token",
+			Repository:           "test/repo",
+			Categories:           map[int]string{1: "DIC_kwDOtest123"},
+			RateLimitDelay:       1 * time.Second,
+			MaxRetries:           3,
+			RetryBackoffMultiple: 2,
 		},
 		Migration: config.MigrationConfig{
 			MaxRetries:   3,
@@ -85,7 +93,8 @@ func TestEndToEndWithMocks(t *testing.T) {
 			ProgressFile: filepath.Join(tempDir, "progress.json"),
 		},
 		Filesystem: config.FilesystemConfig{
-			AttachmentsDir: filepath.Join(tempDir, "attachments"),
+			AttachmentsDir:           filepath.Join(tempDir, "attachments"),
+			AttachmentRateLimitDelay: 500 * time.Millisecond,
 		},
 	}
 

--- a/test/testdata/sample_bbcode.txt
+++ b/test/testdata/sample_bbcode.txt
@@ -23,3 +23,7 @@ And an attachment: [ATTACH=123]
 [center]Centered text[/center]
 
 [color=red]Red text[/color] and [size=20]large text[/size].
+
+Thanks @admin for the help! Also ping @moderator-user and @user_name.
+
+But don't convert emails like contact@example.com or user@domain.org.


### PR DESCRIPTION
- Add configurable rate limiting with delay between API calls
- Implement exponential backoff retry logic for rate-limited requests
- Add RateLimitError struct for proper error handling
- Update NewClient to accept rate limiting configuration parameters
- Wrap API mutations and queries with retry logic using executeWithRetry
- Add configuration options: GITHUB_RATE_LIMIT_DELAY, GITHUB_MAX_RETRIES, GITHUB_RETRY_BACKOFF_MULTIPLE
- Update documentation in README.md and ARCHITECTURE.md with new environment variables
- Enhance integration tests to support new client parameters

This improves the tool's resilience when working with GitHub's API rate limits
and provides better user experience during large migrations.